### PR TITLE
add nodenv subcommand to run default-packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ optionally specify a semver version spec after the name. For example:
 
 Blank lines and lines beginning with a `#` are ignored.
 
+## Updating Default Packages
+
+if you update your `$(nodenv root)/default-packages` and want to refresh some or all of
+your existing node installations you can use commands like this:
+
+    nodenv default-packages install 8.8.1   # Reinstall default packages on Node version 8.8.1
+    nodenv default-packages install --all   # Reinstall default packages on _all_ installed Node versions
+
+*NOTE:* This may take some time.
+
 ## Credits
 
 Forked from [Sam Stephenson][sstephenson]'s [rbenv-default-gems][] by [Josh Hagins][jawshooah] and modified for [nodenv][].

--- a/bin/nodenv-default-packages
+++ b/bin/nodenv-default-packages
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Summary: Refresh default packages on all installed node versions
+#
+# Usage: nodenv default-packages install [ --all | <version>...]
+#
+# Install default packages on a specific version or all installed versions.
+
+set -e
+[ -n "$NODENV_DEBUG" ] && set -x
+
+versions() {
+  case "$1" in
+    "")    nodenv version-name    ;; # list active version
+    --all) nodenv versions --bare ;; # list all installed versions
+    *)     echo "$@"              ;; # list specified versions
+  esac
+}
+
+for_versions() {
+  cmd="$1"
+  shift
+
+  for v in $(versions "$@"); do
+    eval "$cmd" "$(nodenv prefix "$v")"
+  done
+}
+
+install_default_packages() {
+  if [ -f "${NODENV_ROOT}/default-packages" ]; then
+    local line package_name package_version package_spec
+
+    # Read package names and versions from $NODENV_ROOT/default-packages.
+    while IFS=" " read -r -a line; do
+
+      # Skip empty lines.
+      [ "${#line[@]}" -gt 0 ] || continue
+
+      # Skip comment lines that begin with `#`.
+      [ "${line[0]:0:1}" != "#" ] || continue
+
+      package_name="${line[0]}"
+      package_version="${line[*]:1}"
+
+      if [ -n "$package_version" ]; then
+        package_spec="${package_name}@${package_version}"
+      else
+        package_spec="$package_name"
+      fi
+
+      # Invoke `npm install -g` in the just-installed Node.
+      NODENV_VERSION="$VERSION_NAME" nodenv-exec npm install -g "$package_spec" || {
+        echo "nodenv: error installing package \`$package_name'"
+      } >&2
+
+    done < "${NODENV_ROOT}/default-packages"
+  fi
+}
+
+unset cmd
+
+case "$1" in
+# Provide nodenv completions
+  --complete )
+    echo install
+    echo --all
+    exit
+    ;;
+  install )
+    cmd="$1"
+    shift
+    ;;
+  *)
+    nodenv help --usage default-packages 
+    exit 1
+    ;;
+esac
+
+for_versions "${cmd}_default_packages" "$@"

--- a/bin/nodenv-default-packages
+++ b/bin/nodenv-default-packages
@@ -11,9 +11,9 @@ set -e
 
 versions() {
   case "$1" in
-    "")    nodenv version-name    ;; # list active version
-    --all) nodenv versions --bare ;; # list all installed versions
-    *)     echo "$@"              ;; # list specified versions
+    "")    nodenv version-name                   ;; # list active version
+    --all) nodenv versions --skip-aliases --bare ;; # list all installed versions
+    *)     echo "$@"                             ;; # list specified versions
   esac
 }
 

--- a/etc/nodenv.d/install/default-packages.bash
+++ b/etc/nodenv.d/install/default-packages.bash
@@ -9,32 +9,8 @@ install_default_packages() {
   # Only install default packages after successfully installing Node.
   [ "$STATUS" = "0" ] || return 0
 
-  if [ -f "${NODENV_ROOT}/default-packages" ]; then
-    local line package_name package_version package_spec
+  nodenv-default-packages install "$VERSION_NAME"
+  echo "Installed default packages for $VERISON_NAME"
 
-    # Read package names and versions from $NODENV_ROOT/default-packages.
-    while IFS=" " read -r -a line; do
-
-      # Skip empty lines.
-      [ "${#line[@]}" -gt 0 ] || continue
-
-      # Skip comment lines that begin with `#`.
-      [ "${line[0]:0:1}" != "#" ] || continue
-
-      package_name="${line[0]}"
-      package_version="${line[*]:1}"
-
-      if [ -n "$package_version" ]; then
-        package_spec="${package_name}@${package_version}"
-      else
-        package_spec="$package_name"
-      fi
-
-      # Invoke `npm install -g` in the just-installed Node.
-      NODENV_VERSION="$VERSION_NAME" nodenv-exec npm install -g "$package_spec" || {
-        echo "nodenv: error installing package \`$package_name'"
-      } >&2
-
-    done < "${NODENV_ROOT}/default-packages"
-  fi
 }
+

--- a/install.sh
+++ b/install.sh
@@ -4,16 +4,20 @@
 # Installs nodenv-default-packages under $PREFIX.
 
 set -e
-set -u
-
-cd "$(dirname "$0")"
 
 if [ -z "${PREFIX}" ]; then
   PREFIX="/usr/local"
 fi
 
+set -u
+
+cd "$(dirname "$0")"
+
+BIN_PATH="${PREFIX}/bin"
 ETC_PATH="${PREFIX}/etc/nodenv.d"
 
+mkdir -p "$BIN_PATH"
 mkdir -p "$ETC_PATH"
 
+cp -RPp bin/* "$BIN_PATH"
 cp -RPp etc/nodenv.d/* "$ETC_PATH"

--- a/install.sh
+++ b/install.sh
@@ -4,14 +4,11 @@
 # Installs nodenv-default-packages under $PREFIX.
 
 set -e
-
-if [ -z "${PREFIX}" ]; then
-  PREFIX="/usr/local"
-fi
-
 set -u
 
 cd "$(dirname "$0")"
+
+PREFIX="${PREFIX:=/usr/local}"
 
 BIN_PATH="${PREFIX}/bin"
 ETC_PATH="${PREFIX}/etc/nodenv.d"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "nodenv-default-packages",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bats": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-0.4.2.tgz",
+      "integrity": "sha1-gfIiu8uwg9FSiz6IMKbo8xSHbsY=",
+      "dev": true
+    },
+    "bats-assert": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bats-assert/-/bats-assert-1.1.1.tgz",
+      "integrity": "sha1-E+8EWuvEJZSWyKG3/x7otPguWM0=",
+      "dev": true
+    },
+    "bats-mock": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bats-mock/-/bats-mock-1.0.1.tgz",
+      "integrity": "sha1-+G19H84+RhU4L2PemvX/3+dN9dU=",
+      "dev": true
+    },
+    "brew-publish": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/brew-publish/-/brew-publish-2.2.0.tgz",
+      "integrity": "sha512-0d8neRrawePfzYyq8zpXkJRwE5I0mEB8ksPN2cnuOxXffo975HJ4jD5JB7gSb59tLp3xlSNIC0ou/1Bw3329MQ==",
+      "dev": true
+    }
+  }
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -11,6 +11,7 @@ export NODENV_ROOT="${NODENV_TEST_DIR}"
 
 PATH=/usr/bin:/bin:/usr/sbin:/sbin
 PATH="$BATS_TEST_DIRNAME/helpers/bin:$PATH"
+PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
 PATH="$BATS_MOCK_BINDIR:$PATH"
 export PATH
 


### PR DESCRIPTION
This allows reinstallation of default packages on existing node versions. 

This is useful if your default-packages file changes.