### PR TITLE
List packages just once

### DIFF
--- a/bin/nodenv-default-packages
+++ b/bin/nodenv-default-packages
@@ -2,9 +2,12 @@
 #
 # Summary: Refresh default packages on all installed node versions
 #
-# Usage: nodenv default-packages install [ --all | <version>...]
-#
 # Install default packages on a specific version or all installed versions.
+#
+# Usage:
+#   nodenv default-packages list
+#   nodenv default-packages install [ --all | <version>...]
+#
 
 set -e
 [ -n "$NODENV_DEBUG" ] && set -x
@@ -26,7 +29,7 @@ versions() {
 }
 
 for_versions() {
-  cmd="$1"
+  local cmd="$1"
   shift
 
   for v in $(versions "$@"); do

--- a/bin/nodenv-default-packages
+++ b/bin/nodenv-default-packages
@@ -78,11 +78,11 @@ install_default_packages() {
 unset cmd
 
 case "$1" in
-  install | list ) cmd="$1"; shift ;;
+  install ) for_versions install_default_packages "${@:2}" ;;
+
+  list ) list_default_packages ;;
 
   -h | --help ) nodenv-help; exit ;;
 
   *) nodenv-help --usage default-packages; exit 1 ;;
 esac
-
-for_versions "${cmd}_default_packages" "$@"

--- a/bin/nodenv-default-packages
+++ b/bin/nodenv-default-packages
@@ -77,6 +77,8 @@ unset cmd
 case "$1" in
   install | list ) cmd="$1"; shift ;;
 
+  -h | --help ) nodenv-help; exit ;;
+
   *) nodenv-help --usage default-packages; exit 1 ;;
 esac
 

--- a/etc/nodenv.d/install/default-packages.bash
+++ b/etc/nodenv.d/install/default-packages.bash
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 if declare -Ff after_install >/dev/null; then
   after_install install_default_packages
 else
@@ -12,5 +10,4 @@ install_default_packages() {
 
   nodenv-default-packages install "$VERSION_NAME"
   echo "Installed default packages for $VERSION_NAME"
-
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,11 @@
       "resolved": "https://registry.npmjs.org/brew-publish/-/brew-publish-2.3.1.tgz",
       "integrity": "sha512-JtitWM9jtnQk2gerUbvpiYJqUPYrvU43Wet1FDm9w81nJJO4BLAeVLUTFWQTQkV7QtE3AVO203R/67NeTMxzVw==",
       "dev": true
+    },
+    "shellcheck": {
+      "version": "github:jasonkarns/shellcheck#3264bd4340a00978e9c75a3767508d750bb7fb46",
+      "from": "github:jasonkarns/shellcheck#install-hook",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
     },
     "bats-assert": {
       "version": "github:jasonkarns/bats-assert-1#8200039faf9790c05d9865490c97a0e101b9c80f",
+      "from": "github:jasonkarns/bats-assert-1",
       "dev": true
     },
     "bats-mock": {
@@ -22,6 +23,7 @@
     },
     "bats-support": {
       "version": "github:jasonkarns/bats-support#004e707638eedd62e0481e8cdc9223ad471f12ee",
+      "from": "github:jasonkarns/bats-support",
       "dev": true
     },
     "brew-publish": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bats-assert": "jasonkarns/bats-assert-1",
     "bats-mock": "^1.0.1",
     "bats-support": "jasonkarns/bats-support",
-    "brew-publish": "^2.3.1"
+    "brew-publish": "^2.3.1",
+    "shellcheck": "github:jasonkarns/shellcheck#install-hook"
   }
 }

--- a/test/install.bats
+++ b/test/install.bats
@@ -5,12 +5,13 @@ load test_helper
 export INSTALL_HOOK="${BATS_TEST_DIRNAME}/../etc/nodenv.d/install/default-packages.bash"
 
 @test "running nodenv-install auto installs packages" {
-  touch "${NODENV_ROOT}/default-packages"
-  echo "fake-package" >> "${NODENV_ROOT}/default-packages"
+  with_default_packages_file <<< fake-package
+
   stub nodenv-prefix '0.10.36 : echo "$NODENV_ROOT/versions/0.10.36"'
   stub nodenv-version-name 'echo 0.10.36'
   stub nodenv-which 'npm : echo "${NODENV_ROOT}/versions/0.10.36/bin/npm"'
   stub nodenv-hooks 'exec : echo ""'
+
   run nodenv-install 0.10.36
 
   assert_success

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -20,3 +20,8 @@ teardown() {
   rm -rf "$NODENV_TEST_DIR"
   rm -rf "$BATS_MOCK_TMPDIR"
 }
+
+with_default_packages_file() {
+  touch "${NODENV_ROOT}/default-packages"
+  cat - >> "${NODENV_ROOT}/default-packages"
+}


### PR DESCRIPTION
Initial release of the `list` subcommand errantly listed the packages
for each node version, which is rather pointless. This changes the
`list` subcommand to only list the default-packages once. (essentially
cat of the default-packages file, but as it parsed for installing)