### PR TITLE
Only run npm-install once

### DIFF
--- a/bin/nodenv-default-packages
+++ b/bin/nodenv-default-packages
@@ -68,7 +68,7 @@ default_packages_files() {
 
   if [ -z "${file_found:-}" ]; then
     echo "nodenv: default-packages file not found" >&2
-    return 1
+    exit 1
   fi
 }
 

--- a/bin/nodenv-default-packages
+++ b/bin/nodenv-default-packages
@@ -22,6 +22,14 @@ if [ "$1" = --complete ]; then
   exit
 fi
 
+# GNU xargs requires -r flag for skip-if-empty behavior
+# BSD xargs does this by default (but doesn't accept -r option)
+if xargs --version 2>&1 | grep -q GNU; then
+  xargs() {
+    command xargs -r "$@"
+  }
+fi
+
 versions() {
   case "$1" in
     "")    nodenv-version-name                   ;; # list active version

--- a/bin/nodenv-default-packages
+++ b/bin/nodenv-default-packages
@@ -50,28 +50,9 @@ list_default_packages() {
   done
 }
 
-npm_install() {
-  local node_version=$1
-  local package=$2
-
-  NODENV_VERSION="$node_version" nodenv-exec npm install -g "$package"
-}
-
 install_default_packages() {
-  local node_version="$1"
-  shift
-
-  local package
-
   list_default_packages |
-  {
-    local error
-    while read -r package; do
-      npm_install "$node_version" "$package" || error=true
-    done
-
-    [ -z "$error" ] || exit 1
-  }
+  NODENV_VERSION="$1" xargs nodenv-exec npm install -g
 }
 
 default_packages_files() {

--- a/test/install.bats
+++ b/test/install.bats
@@ -51,3 +51,13 @@ PKGS
   assert_success
   assert_output -p "npm invoked with: install -g pkg1 pkg2"
 }
+
+@test "install does not invoke npm if no packages to install" {
+  nodenv install --no-hooks 10.0.0
+  with_file "$NODENV_ROOT/default-packages" <<<""
+
+  run nodenv default-packages install 10.0.0
+
+  assert_success
+  refute_output
+}

--- a/test/install.bats
+++ b/test/install.bats
@@ -38,3 +38,16 @@ load test_helper
   assert_success
   assert_output -p "npm invoked with: install -g fake-package"
 }
+
+@test "install npm-installs multiple packages in one command" {
+  nodenv install --no-hooks 10.0.0
+  with_file "$NODENV_ROOT/default-packages" <<-PKGS
+	pkg1
+	pkg2
+PKGS
+
+  run nodenv default-packages install 10.0.0
+
+  assert_success
+  assert_output -p "npm invoked with: install -g pkg1 pkg2"
+}


### PR DESCRIPTION
Instead of iterating over every package, we can invoke npm just once for
all the expected packages.