### PR TITLE
Restore bats-support as explicit devDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,15 @@
       "name": "@nodenv/nodenv-default-packages",
       "version": "1.0.1",
       "license": "MIT",
+      "bin": {
+        "nodenv-default-packages": "bin/nodenv-default-packages"
+      },
       "devDependencies": {
         "@nodenv/nodenv": "^1.6.2",
         "bats": "^1.12.0",
         "bats-assert": "^2.2.0",
         "bats-mock": "^1.2.5",
+        "bats-support": "^0.3.0",
         "prettier": "^3.6.2",
         "shellcheck": "^3.1.0"
       }
@@ -91,10 +95,10 @@
     },
     "node_modules/bats-support": {
       "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/jasonkarns/bats-support.git#0ad082d4590108684c68975ca517a90459f05cd0",
+      "resolved": "https://registry.npmjs.org/bats-support/-/bats-support-0.3.0.tgz",
+      "integrity": "sha512-z+2WzXbI4OZgLnynydqH8GpI3+DcOtepO66PlK47SfEzTkiuV9hxn9eIQX+uLVFbt2Oqoc7Ky3TJ/N83lqD+cg==",
       "dev": true,
       "license": "CC0-1.0",
-      "peer": true,
       "peerDependencies": {
         "bats": "0.4 || ^1"
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bats": "^1.12.0",
     "bats-assert": "^2.2.0",
     "bats-mock": "^1.2.5",
+    "bats-support": "^0.3.0",
     "prettier": "^3.6.2",
     "shellcheck": "^3.1.0"
   }


### PR DESCRIPTION
It was removed because npm 7+ now installs peer deps by default, and
bats-support is a peerDep of bats-assert.

However, that implies a version restriction that this plugin depends on
npm 7+. But that restriction only applies to _development_. We could put
the restriction on bats-assert, (which would be more aligned with it as
a dev dep). But it's not technically true because any dependent of
bats-assert could avoid the npm restriction by simply installing
bats-support _explicitly_.

Which leads us back to the main point. bats-support is loaded _from_ the
parent dependent. So it should be an explicit devDep at that location.
